### PR TITLE
Merge Develop to Master

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,14 +63,7 @@ Tests
 
 ::
 
-    from ejabberdctl.tests import ejabberdctl_tests
-
-    host = 'example.com'
-    username = 'admin'
-    password = 'admin'
-
-    tests = ejabberdctl_tests(host, username, password)
-    tests.run_all()
+    python ejabberdctl/tests.py
 
 
 Coverage

--- a/ejabberdctl/ejabberdctl.py
+++ b/ejabberdctl/ejabberdctl.py
@@ -1,7 +1,4 @@
-
-
 import xmlrpc.client
-
 from http.client import BadStatusLine, RemoteDisconnected
 
 

--- a/ejabberdctl/ejabberdctl.py
+++ b/ejabberdctl/ejabberdctl.py
@@ -39,9 +39,11 @@ class ejabberdctl(object):
                 return fn(self.params, payload)
             return fn(self.params)
         except BadStatusLine as e:
+            print("CTL_BadStatusLine > ", e)
             raise Exception('{}\n{}'.format(self.errors['connect'],
                                             e.message))
         except xmlrpc.client.Fault as e:
+            print("CTL_xmlrpc > ", e)
             if 'account_unprivileged' in e.message:
                 raise Exception('{}\n{}'.format(self.errors['access'],
                                                 e.message))
@@ -813,3 +815,10 @@ class ejabberdctl(object):
         Get information about all sessions of a user
         '''
         return self.ctl('user_sessions_info', {'user': user, 'host': host})
+
+    def remove_mam_for_user(user, server):
+        '''
+        Remove user archive
+        '''
+        return self.ctl('remove_mam_for_user', {'user': user, 'server': server})
+

--- a/ejabberdctl/ejabberdctl.py
+++ b/ejabberdctl/ejabberdctl.py
@@ -2,7 +2,7 @@
 
 import xmlrpc.client
 
-from http.client import BadStatusLine
+from http.client import BadStatusLine, RemoteDisconnected
 
 
 class ejabberdctl(object):
@@ -38,6 +38,9 @@ class ejabberdctl(object):
             if payload:
                 return fn(self.params, payload)
             return fn(self.params)
+        except RemoteDisconnected as e:
+            print("CTL_RemoteDisconnected > ", e)
+            raise Exception('{}\n{}'.format(self.errors['connect'], e))
         except BadStatusLine as e:
             print("CTL_BadStatusLine > ", e)
             raise Exception('{}\n{}'.format(self.errors['connect'],

--- a/ejabberdctl/ejabberdctl.py
+++ b/ejabberdctl/ejabberdctl.py
@@ -816,7 +816,7 @@ class ejabberdctl(object):
         '''
         return self.ctl('user_sessions_info', {'user': user, 'host': host})
 
-    def remove_mam_for_user(user, server):
+    def remove_mam_for_user(self, user, server):
         '''
         Remove user archive
         '''

--- a/ejabberdctl/tests.py
+++ b/ejabberdctl/tests.py
@@ -10,24 +10,16 @@ class ejabberdctl_tests(object):
     ejabberdctl.py testing suite.
     '''
 
-    def __init__(self, server, port, host, username, password):
+    def __init__(self, host, username, password):
         '''
         Initialise the testing suite for
         Ejabberd XML-RPC Administration API client.
         '''
-        self.server = server
-        self.port = port
         self.host = host
         self.username = username
         self.password = password
 
-        self.ctl = ejabberdctl(
-            server=server,
-            port=port,
-            host=host,
-            username=username,
-            password=password
-        )
+        self.ctl = ejabberdctl(host, username, password)
 
     def run_all(self):
         '''
@@ -838,7 +830,7 @@ class TestEjabberdCtl(TestCase):
         )
     
     @mock.patch('ejabberdctl.ejabberdctl.ctl')
-    def test_add_roster_item_failed(self, mock_ctl):
+    def test_get_status_failed(self, mock_ctl):
         mock_ctl.side_effect = RemoteDisconnected()
         with self.assertRaises(Exception) as cm:
             self.ctl.status()

--- a/ejabberdctl/tests.py
+++ b/ejabberdctl/tests.py
@@ -1,6 +1,7 @@
+import unittest
 from http.client import RemoteDisconnected
 from unittest import TestCase, mock
-import unittest
+
 from ejabberdctl import ejabberdctl
 
 

--- a/ejabberdctl/tests.py
+++ b/ejabberdctl/tests.py
@@ -830,7 +830,7 @@ class TestEjabberdCtl(TestCase):
         )
     
     @mock.patch('ejabberdctl.ejabberdctl.ctl')
-    def test_get_status_failed(self, mock_ctl):
+    def test_remote_disconnected_exception(self, mock_ctl):
         mock_ctl.side_effect = RemoteDisconnected()
         with self.assertRaises(Exception) as cm:
             self.ctl.status()


### PR DESCRIPTION
This PR aims to handle the `RemoteDisconnected` exception properly.

Closes https://github.com/senseobservationsystems/goalie-backend/issues/3274

## Changelog
### Added
- the unit test for `RemoteDisconnected` exception

### Changes
- the test instruction in the `Readme.srt` file
- the `ejabberdctl/ejabberdctl.py > ctl` method 